### PR TITLE
Force supplying external search paths

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,5 +17,5 @@
 
  1. Place the script in your path
  2. Create an alias to call this script in your shells .rc config: 
-    bindkey -s ^f "zellij-sessionizer\n"
+    bindkey -s ^f "zellij-sessionizer path1 path2 etc..\n"
  3. Update which paths you'd like to search in

--- a/zellij-sessionizer
+++ b/zellij-sessionizer
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
 
-# Use an argument if passed
-if [[ $# -eq 1 ]]; then
-    selected_path=$1
-else
-	# If no argument was provided, interactively choose a directory
 
-	# Check whether the machine has fd available
+paths=$@
+
+if [[ -z $paths ]]; then 
+	echo "No paths were specified, usage: ./zellij-sessionizer path1 path2 etc.."
+	exit 0
+fi
+
+# Use an argument if passed
+    selected_path=$1
+		# Check whether the machine has fd available
 	if [ -x "$(command -v fd)" ]; then
-    selected_path=$(fd . ~/dev --min-depth 1 --max-depth 2 --type d | fzf)
+    selected_path=$(fd . $paths --min-depth 1 --max-depth 2 --type d | fzf)
 	else
 		# defer to find if not
-		selected_path=$(find ~/dev -mindepth 1 -maxdepth 2 -type d | fzf)
+		selected_path=$(find $paths -mindepth 1 -maxdepth 2 -type d | fzf)
 	fi
-fi
 
 # If no directory was selected, exit the script
 if [[ -z $selected_path ]]; then


### PR DESCRIPTION
In order to improve ergonomics, I would like to make the search paths
- to be passed from outside rather than hardcoded inside the script itself.