### PR TITLE
FEATURE: allow to pass paths from outside without searching in them

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,14 +37,16 @@ in my `config.nu` file, i've added the following binding under `$env.config.keyb
      mode: [emacs, vi_insert, vi_normal]
      event: {
          send: executehostcommand
-         cmd: "zellij-sessionizer.nu $env.GIT_REPOS_HOME"
+         cmd: "zellij-sessionizer.nu [--depth/-d] ...paths"
      }
  }
 ```
-given that
-- `zellij-sessionizer.nu` is in your `$env.PATH`,
-- `$env.GIT_REPOS_HOME` is some variable defined in `env.nu` that points to a
-place with lots of projects,
+given that `zellij-sessionizer.nu` is in your `$env.PATH`.
+
+here the `...` represents any set of arguments and options, e.g.
+- a command that lists all the paths directly: `gm list --full-path`
+- a more complex one: `[~/.local/share/repos/ ~/documents/] | each { ls $in | where type == dir | get name } | flatten`
+- or let `zellij-sessionizer.nu` handle the search at some depth: `~/.local/share/repos/ ~/documents/ --depth 1`
 
 this binding will run the sessionizer simply by pressing `<C-f>` :ok_hand:
 

--- a/zellij-sessionizer.nu
+++ b/zellij-sessionizer.nu
@@ -11,20 +11,20 @@ def is-inside-zellij [] {
 def main [
     path: path  # the directory to search projects inside
 ] {
-    let project = (if (which fd | is-empty) {
+    let directory = (if (which fd | is-empty) {
         ^find $path -mindepth 1 -maxdepth 2 -type d
     } else {
         ^fd . $path --min-depth 1 --max-depth 2 --type d
     } | fzf)
 
-    if ($project | is-empty) {
+    if ($directory | is-empty) {
         return
     }
 
-    let session = ($project | path basename)
+    let session = ($directory | path basename)
 
     if not (is-inside-zellij) {
-        cd $project
+        cd $directory
         zellij attach --create $session options --default-shell nu
         return
     }
@@ -34,6 +34,6 @@ def main [
     # Hopefully they'll someday support specifying a directory and this won't be
     # as laggy thanks to @msirringhaus for getting this from the community some
     # time ago!
-    zellij action write-chars $"cd ($project)"
+    zellij action write-chars $"cd ($directory)"
     zellij action write 10
 }

--- a/zellij-sessionizer.nu
+++ b/zellij-sessionizer.nu
@@ -6,10 +6,16 @@ def is-inside-zellij [] {
 
 # attach to a Zellij session by fuzzy finding projects
 #
-# the projects are computed by listing all the directories at depth between 1
-# and 2 recursively under the `path` argument.
+# # Examples
+#     opening a session by listing `nu-git-manager` repositories
+#     > zellij-sessionizer.nu (gm list --full-path)
+#
+#     open a session in local repos and documents
+#     > zellij-sessionizer.nu (
+#     >     [~/.local/share/repos/ ~/documents/] | each { ls $in | where type == dir | get name } | flatten
+#     > )
 def main [
-    ...paths: path
+    ...paths: path  # the list of paths to fuzzy find
 ] {
     if ($paths | is-empty) {
         error make --unspanned {msg: "no path given"}


### PR DESCRIPTION
related to 
- https://github.com/silicakes/zellij-sessionizer/issues/4

this PR allows to pass directories from outside of the *sessionizer* without searching recursively in them.
the `zellij-sessionizer.nu` script also supports passing a `--depth: int` to recursively search inside the `...paths` at the given depth :ok_hand: 

hopefully this brings best of both worlds :relieved: :crossed_fingers: 